### PR TITLE
Field distinct patch

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -144,6 +144,7 @@ $chart_options = [
 - `continuous_time` (optional) - show all dates on chart, including dates without data.
 - `range_date_start` (optional) - show data in from a date range by `filter_field`, this is the start date.
 - `range_date_end` (optional) - show data in from a date range by `filter_field`, this is the end date.
+- `field_distinct` (optional) - field name required, it will apply a distinct(fieldname)
 
 - - - - -
 

--- a/src/Classes/LaravelChart.php
+++ b/src/Classes/LaravelChart.php
@@ -102,6 +102,9 @@ class LaravelChart {
                         }
                     })
                     ->map(function ($entries) {
+                        if(isset($this->options['field_distinct'])) {
+							$entries=$entries->unique($this->options['field_distinct']);
+						}
                         $aggregate = $entries->{$this->options['aggregate_function'] ?? 'count'}($this->options['aggregate_field'] ?? '');
                         if (@$this->options['aggregate_transform']) {
                             $aggregate = $this->options['aggregate_transform']($aggregate);
@@ -163,6 +166,7 @@ class LaravelChart {
             'chart_type' => 'chart_type',
             'filter_days' => 'filter_days',
             'filter_period' => 'filter_period',
+            'field_distinct' => 'field_distinct',
         ];
 
         $validator = Validator::make($options, $rules, $messages, $attributes);

--- a/src/Classes/LaravelChart.php
+++ b/src/Classes/LaravelChart.php
@@ -103,8 +103,8 @@ class LaravelChart {
                     })
                     ->map(function ($entries) {
                         if(isset($this->options['field_distinct'])) {
-							$entries=$entries->unique($this->options['field_distinct']);
-						}
+                            $entries = $entries->unique($this->options['field_distinct']);
+                        }
                         $aggregate = $entries->{$this->options['aggregate_function'] ?? 'count'}($this->options['aggregate_field'] ?? '');
                         if (@$this->options['aggregate_transform']) {
                             $aggregate = $this->options['aggregate_transform']($aggregate);


### PR DESCRIPTION
This add the option to run a "distinct" sql command on the query results.

Useful to return count results based on distinct of custom values. 

Es. While having a logs table with a "user_id" field and the chart setup as "group_by_date", this new field can filter logs and show the total amount of users by day if 'field_distinct' is set to "user_id"