### PR TITLE
Fix Data missing Carbon Exception

### DIFF
--- a/src/Classes/LaravelChart.php
+++ b/src/Classes/LaravelChart.php
@@ -119,7 +119,12 @@ class LaravelChart
                                 return $entry->{$this->options['group_by_field']}
                                     ->format($this->options['date_format'] ?? self::GROUP_PERIODS[$this->options['group_by_period']]);
                             } else {
-                                if ($entry->{$this->options['group_by_field']}) {
+                                if ($entry->{$this->options['group_by_field']} && $this->options['group_by_field_format']) {
+                                    return \Carbon\Carbon::createFromFormat($this->options['group_by_field_format'],
+                                        $entry->{$this->options['group_by_field']}
+                                    )
+                                        ->format($this->options['date_format'] ?? self::GROUP_PERIODS[$this->options['group_by_period']]);
+                                }else if ($entry->{$this->options['group_by_field']}) {
                                     return \Carbon\Carbon::createFromFormat('Y-m-d H:i:s',
                                         $entry->{$this->options['group_by_field']}
                                     )


### PR DESCRIPTION
Fix error when group_by_field is a Date column in the format of 'Y-m-d'. Pass group_by_field_format option when creating the chart