### PR TITLE
Added possibility to disregard global scope on model

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -153,6 +153,7 @@ $chart_options = [
 - `where_raw` (optional) - Condition in multiple consultation situations
 - `chart_height` (optional) - add the height in options, default 300px
 - `date_format_filter_days` (optional) -add the date format for Filter days
+- `withoutGlobalScopes` (optional) -removes global scope restriction from queried model
 
 - - - - -
 

--- a/src/Classes/LaravelChart.php
+++ b/src/Classes/LaravelChart.php
@@ -97,7 +97,7 @@ class LaravelChart
                     $query->with($this->options['relationship_name']);
                 }
 
-                if($this->options['withoutGlobalScopes']){
+                if(isset($this->options['withoutGlobalScopes']) && $this->options['withoutGlobalScopes']){
                     $collection = $query->withoutGlobalScopes()->get();
                 } else {
                     $collection = $query->get();

--- a/src/Classes/LaravelChart.php
+++ b/src/Classes/LaravelChart.php
@@ -97,7 +97,11 @@ class LaravelChart
                     $query->with($this->options['relationship_name']);
                 }
 
-                $collection = $query->get();
+                if($this->options['withoutGlobalScopes']){
+                    $collection = $query->withoutGlobalScopes()->get();
+                } else {
+                    $collection = $query->get();
+                }
 
                 if ($this->options['report_type'] != 'group_by_relationship') {
                     $collection->where($this->options['group_by_field'], '!=', '');


### PR DESCRIPTION
Global scopes are often used on models to limit visibility of model's records visibility to owned ones only.
However on dashboard may may need to show global statistics and this global scope needs to be disregarded.