### PR TITLE
Show blank data

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -146,6 +146,7 @@ $chart_options = [
 - `filter_days` (optional) - see `filter_field` above - show only last `filter_days` days of that field. Example, last __30__ days by `created_at` field.
 - `filter_period` (optional) - another way to filter by field, show only record from last __week__ / __month__ / __year__. Possible values are "week", "month", "year".
 - `continuous_time` (optional) - show all dates on chart, including dates without data.
+- `show_blank_data` (optional) - show date even if the data is blank based on `filter_days`.
 - `range_date_start` (optional) - show data in from a date range by `filter_field`, this is the start date.
 - `range_date_end` (optional) - show data in from a date range by `filter_field`, this is the end date.
 - `field_distinct` (optional) - field name required, it will apply a distinct(fieldname)

--- a/src/Classes/LaravelChart.php
+++ b/src/Classes/LaravelChart.php
@@ -175,13 +175,17 @@ class LaravelChart
                 }
 
 
-                if (isset($this->options['filter_days']) && @$this->options['show_blank_data']) {
+                if (
+                    isset($this->options['group_by_period']) &&
+                    isset($this->options['filter_days']) &&
+                    @$this->options['show_blank_data']
+                ) {
                     $newData = collect([]);
 
                     CarbonPeriod::since(now()->subDays($this->options['filter_days']))
                         ->until(now())
                         ->forEach(function (Carbon $date) use ($data, &$newData) {
-                            $key = $date->format($this->options['date_format'] ?? 'Y-m-d');
+                            $key = $date->format(self::GROUP_PERIODS[$this->options['group_by_period']]);
                             $newData->put($key, $data[$key] ?? 0);
                         });
 

--- a/src/Classes/LaravelChart.php
+++ b/src/Classes/LaravelChart.php
@@ -176,16 +176,17 @@ class LaravelChart
 
 
                 if (
-                    isset($this->options['group_by_period']) &&
+                    (isset($this->options['date_format']) || isset($this->options['group_by_period'])) &&
                     isset($this->options['filter_days']) &&
                     @$this->options['show_blank_data']
                 ) {
                     $newData = collect([]);
+                    $format = $this->options['date_format'] ?? self::GROUP_PERIODS[$this->options['group_by_period']];
 
                     CarbonPeriod::since(now()->subDays($this->options['filter_days']))
                         ->until(now())
-                        ->forEach(function (Carbon $date) use ($data, &$newData) {
-                            $key = $date->format(self::GROUP_PERIODS[$this->options['group_by_period']]);
+                        ->forEach(function (Carbon $date) use ($data, &$newData, $format) {
+                            $key = $date->format($format);
                             $newData->put($key, $data[$key] ?? 0);
                         });
 

--- a/src/Classes/LaravelChart.php
+++ b/src/Classes/LaravelChart.php
@@ -175,6 +175,19 @@ class LaravelChart
                 }
 
 
+                if (isset($this->options['filter_days']) && @$this->options['show_blank_data']) {
+                    $newData = collect([]);
+
+                    CarbonPeriod::since(now()->subDays($this->options['filter_days']))
+                        ->until(now())
+                        ->forEach(function (Carbon $date) use ($data, &$newData) {
+                            $key = $date->format($this->options['date_format'] ?? 'Y-m-d');
+                            $newData->put($key, $data[$key] ?? 0);
+                        });
+
+                    $data = $newData;
+                }
+
                 if (@$this->options['continuous_time']) {
                     $dates = $data->keys();
                     $interval = $this->options['group_by_period'] ?? 'day';


### PR DESCRIPTION
This PR added an option to show the date even if the data is "blank"

when the option is not used:
![image](https://user-images.githubusercontent.com/32760797/145846293-7b6790b2-947e-4c54-9e8c-6520221e7923.png)

when the option is used:
![image](https://user-images.githubusercontent.com/32760797/145846394-3abc152d-c4f7-4f77-8d85-7eaa2e4bdfad.png)

here is the data for likes table:
![image](https://user-images.githubusercontent.com/32760797/145846547-11087603-aa85-417b-82f2-05ccfdb31b05.png)


with multiple datasets, this may cause the data to be incorrectly displayed
