### PR TITLE
[FTR] Add option to hide dataset by default and give pie charts a specific color per group

### DIFF
--- a/src/Classes/LaravelChart.php
+++ b/src/Classes/LaravelChart.php
@@ -251,6 +251,7 @@ class LaravelChart
             'chart_type'            => 'required|in:line,bar,pie|bail',
             'filter_days'           => 'integer',
             'filter_period'         => 'in:week,month,year',
+            'hidden'                => 'boolean'
         ];
 
         $messages = [
@@ -272,6 +273,7 @@ class LaravelChart
             'filter_days'           => 'filter_days',
             'filter_period'         => 'filter_period',
             'field_distinct'        => 'field_distinct',
+            'hidden'                => 'hidden'
         ];
 
         $validator = Validator::make($options, $rules, $messages, $attributes);

--- a/src/Classes/LaravelChart.php
+++ b/src/Classes/LaravelChart.php
@@ -217,7 +217,14 @@ class LaravelChart
                     }
                 }
 
-                $dataset = ['name' => $this->options['chart_title'], 'color' => $condition['color'], 'chart_color' => $this->options['chart_color'] ?? '', 'fill' => $condition['fill'], 'data' => $data];
+                $dataset = [
+                    'name' => $this->options['chart_title'], 
+                    'color' => $condition['color'], 
+                    'chart_color' => $this->options['chart_color'] ?? '', 
+                    'fill' => $condition['fill'], 
+                    'data' => $data, 
+                    'hidden' => $this->options['hidden'] ?? false
+                ];
             }
             
             if(!empty($this->options['labels'])) {

--- a/src/views/javascript.blade.php
+++ b/src/views/javascript.blade.php
@@ -19,6 +19,9 @@
                         {!! $result !!},
                     @endforeach
                 ],
+                @if($dataset['hidden'] === true)
+                    hidden: true,
+                @endif
                 @if ($options['chart_type'] == 'line')
                     @if (isset($dataset['fill']) && $dataset['fill'] != '')
                         fill: '{{ $dataset['fill'] }}',

--- a/src/views/javascript.blade.php
+++ b/src/views/javascript.blade.php
@@ -38,7 +38,11 @@
                 @elseif ($options['chart_type'] == 'pie')
                     backgroundColor: [
                         @foreach ($dataset['data'] as $group => $result)
-                            'rgba({{ rand(0,255) }}, {{ rand(0,255) }}, {{ rand(0,255) }}, 0.2)',
+                            @if (isset($dataset['chart_color'][$group]) && $dataset['chart_color'][$group] != '')
+                                'rgba({{ $dataset['chart_color'][$group] }})',
+                            @else
+                                'rgba({{ rand(0,255) }}, {{ rand(0,255) }}, {{ rand(0,255) }}, 0.2)',
+                            @endif
                         @endforeach
                     ],
                 @elseif ($options['chart_type'] == 'bar' && isset($dataset['chart_color']) && $dataset['chart_color'] != '')


### PR DESCRIPTION
Adds the option to hide a dataset by default. Can be useful when you have multiple datasets in one chart and want to show only one of them when loading the page.