### PR TITLE
Added stacked option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -161,6 +161,8 @@ $chart_options = [
 - `top_results` (optional, integer) - limit number of results shown, see [Issue #49](https://github.com/LaravelDaily/laravel-charts/issues/49) 
 - `chart_color` (optional, value in rgba, like "0,255,255") - defines the color of the chart
 - `labels` (optional, array with key and value) - defines key value array mapping old and new values
+- `hidden` (optional, boolean) hides the current dataset. Useful when having multiple datasets in one chart
+- `stacked` (optional, boolean, only for bar chart) stacks the chart data when dates or strings match instead of showing it next to eachother  
 
 - - - - -
 

--- a/src/Classes/LaravelChart.php
+++ b/src/Classes/LaravelChart.php
@@ -223,7 +223,8 @@ class LaravelChart
                     'chart_color' => $this->options['chart_color'] ?? '', 
                     'fill' => $condition['fill'], 
                     'data' => $data, 
-                    'hidden' => $this->options['hidden'] ?? false
+                    'hidden' => $this->options['hidden'] ?? false,
+                    'stacked' => $this->options['stacked'] ?? false,
                 ];
             }
             
@@ -258,7 +259,8 @@ class LaravelChart
             'chart_type'            => 'required|in:line,bar,pie|bail',
             'filter_days'           => 'integer',
             'filter_period'         => 'in:week,month,year',
-            'hidden'                => 'boolean'
+            'hidden'                => 'boolean',
+            'stacked'               => 'boolean',
         ];
 
         $messages = [
@@ -280,7 +282,8 @@ class LaravelChart
             'filter_days'           => 'filter_days',
             'filter_period'         => 'filter_period',
             'field_distinct'        => 'field_distinct',
-            'hidden'                => 'hidden'
+            'hidden'                => 'hidden',
+            'stacked'               => 'stacked',
         ];
 
         $validator = Validator::make($options, $rules, $messages, $attributes);

--- a/src/views/javascript.blade.php
+++ b/src/views/javascript.blade.php
@@ -65,7 +65,10 @@
                 yAxes: [{
                     ticks: {
                         beginAtZero:true
-                    }
+                    },
+                    @if($options['chart_type'] == 'bar' && $dataset['stacked'] == true)
+                        stacked: true
+                    @endif
                 }]
             },
         @endif


### PR DESCRIPTION
This pull request adds the stacked option so bar charts can be more compact when using a lot of data.
Also useful when you want to sum up different expenses for companies for example.

![image](https://github.com/LaravelDaily/laravel-charts/assets/123570740/72b62438-34fe-48d4-bb40-51e49bb838c9)
