### PR TITLE
[FIX] Not being able to set name anymore because it gets overwritten

### DIFF
--- a/src/Classes/LaravelChart.php
+++ b/src/Classes/LaravelChart.php
@@ -218,7 +218,7 @@ class LaravelChart
                 }
 
                 $dataset = [
-                    'name' => $this->options['chart_title'], 
+                    'name' => $this->options['name'] ?? $this->options['chart_title'], 
                     'color' => $condition['color'], 
                     'chart_color' => $this->options['chart_color'] ?? '', 
                     'fill' => $condition['fill'], 


### PR DESCRIPTION
The name always got overwritten by chart_title. So setting the name in the dataset did nothing.
I changed it so the chart_title gets used for the name whenever the name has not been set.