### PR TITLE
[FIX] $options['stacked'] throwing error because not set

### DIFF
--- a/src/views/javascript.blade.php
+++ b/src/views/javascript.blade.php
@@ -66,7 +66,7 @@
                     ticks: {
                         beginAtZero:true
                     },
-                    @if($options['chart_type'] == 'bar' && $options['stacked'] == true)
+                    @if($options['chart_type'] == 'bar' && isset($options['stacked']) && $options['stacked'] == true)
                         stacked: true
                     @endif
                 }]


### PR DESCRIPTION
Change from $dataset (always set) to $options (not always set) throwing error.
Noticed this on production environment when the home/dashboard page started crashing since today.