### PR TITLE
Backward compatible for non-English chart title

### DIFF
--- a/src/Classes/LaravelChart.php
+++ b/src/Classes/LaravelChart.php
@@ -33,6 +33,9 @@ class LaravelChart
         foreach (func_get_args() as $arg) {
             $this->options = $arg;
             $this->options['chart_name'] = strtolower(Str::slug($arg['chart_title'], '_'));
+            if ($this->options['chart_name'] == '') {
+                $this->options['chart_name'] = $arg['chart_title'];
+            }
             $this->datasets[] = $this->prepareData();
         }
     }


### PR DESCRIPTION
If non-English string is apply to chart title, the chart won't show anything and comes with javascript error
Reproduce:
```
$chart_options = [
            'chart_title' => '標題', //which is Chinese string
            'report_type' => 'group_by_date',
            'model' => 'App\Models\users',
            'group_by_field' => 'update_at',
            'group_by_period' => 'week',
            'chart_type' => 'bar',
        ];
```

This PR will check the chart title is empty or not, then fall back to the original characters without slugify it.