### PR TITLE
Added caching mechanism

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "eruvaer74/laravel-charts",
+    "name": "laraveldaily/laravel-charts",
     "description": "Create charts and reports from Laravel",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "Eruvaer74/laravel-charts",
+    "name": "eruvaer74/laravel-charts",
     "description": "Create charts and reports from Laravel",
     "license": "MIT",
     "authors": [

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "laraveldaily/laravel-charts",
+    "name": "Eruvaer74/laravel-charts",
     "description": "Create charts and reports from Laravel",
     "license": "MIT",
     "authors": [

--- a/readme.md
+++ b/readme.md
@@ -161,7 +161,7 @@ $chart_options = [
 - `with_trashed` (optional) - includes soft deleted models
 - `only_trashed` (optional) - only displays soft deleted models
 - `top_results` (optional, integer) - limit number of results shown, see [Issue #49](https://github.com/LaravelDaily/laravel-charts/issues/49)
-- `chart_color` (optional, value in rgba, like "0,255,255") - defines the color of the chart
+- `chart_color` (optional, value in rgba, like "0,255,255") - defines the color of the chart. For pie charts provide an array of colors with keys depending on your group_by_field or group_by_period option.
 - `labels` (optional, array with key and value) - defines key value array mapping old and new values
 - `hidden` (optional, boolean) hides the current dataset. Useful when having multiple datasets in one chart
 - `stacked` (optional, boolean, only for bar chart) stacks the chart data when dates or strings match instead of showing it next to eachother

--- a/readme.md
+++ b/readme.md
@@ -92,7 +92,7 @@ return view('dashboard', compact('chart'));
 
 ## Available Reports and Options
 
-Currently package support three types of charts/reports: 
+Currently package support three types of charts/reports:
 
 - `group_by_date` - amount of records from the same table, grouped by time period - day/week/month/year;
 - `group_by_string` - amount of records from the same table, grouped by any string field, like `name`;
@@ -127,6 +127,8 @@ $chart_options = [
     'filter_days' => 30, // show only transactions for last 30 days
     'filter_period' => 'week', // show only transactions for this week
     'continuous_time' => true, // show continuous timeline including dates without data
+    'caching_key' => 'chart1',
+    'caching_time' => 60
 ];
 ```
 
@@ -158,11 +160,13 @@ $chart_options = [
 - `withoutGlobalScopes` (optional) - removes global scope restriction from queried model
 - `with_trashed` (optional) - includes soft deleted models
 - `only_trashed` (optional) - only displays soft deleted models
-- `top_results` (optional, integer) - limit number of results shown, see [Issue #49](https://github.com/LaravelDaily/laravel-charts/issues/49) 
+- `top_results` (optional, integer) - limit number of results shown, see [Issue #49](https://github.com/LaravelDaily/laravel-charts/issues/49)
 - `chart_color` (optional, value in rgba, like "0,255,255") - defines the color of the chart
 - `labels` (optional, array with key and value) - defines key value array mapping old and new values
 - `hidden` (optional, boolean) hides the current dataset. Useful when having multiple datasets in one chart
-- `stacked` (optional, boolean, only for bar chart) stacks the chart data when dates or strings match instead of showing it next to eachother  
+- `stacked` (optional, boolean, only for bar chart) stacks the chart data when dates or strings match instead of showing it next to eachother
+- `caching_key`(optional) - a unique string to identify the chart
+- `caching_time` (optional) - number of seconds the data remains in the cache
 
 - - - - -
 
@@ -193,7 +197,7 @@ $chart_options = [
 
 After you passed `$chart` variable, into Blade, you can render it, by doing __three__ actions:
 
-__Action 1. Render HTML__. 
+__Action 1. Render HTML__.
 
 Wherever in your Blade, call this:
 
@@ -335,7 +339,7 @@ __View__:
 
 ---
 
-## Multiple Datasets 
+## Multiple Datasets
 
 This is a new feature from v0.1.27. You can provide multiple arrays of settings to the `LaravelChart` constructor, and they will be drawn on the same chart.
 

--- a/src/Classes/LaravelChart.php
+++ b/src/Classes/LaravelChart.php
@@ -4,6 +4,7 @@ namespace LaravelDaily\LaravelCharts\Classes;
 
 use Carbon\Carbon;
 use Carbon\CarbonPeriod;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Str;
 
@@ -33,7 +34,13 @@ class LaravelChart
         foreach (func_get_args() as $arg) {
             $this->options = $arg;
             $this->options['chart_name'] = strtolower(Str::slug($arg['chart_title'], '_'));
-            $this->datasets[] = $this->prepareData();
+            if(isset($this->options['caching_key'], $this->options['caching_time'])) {
+                $this->datasets[] = Cache::remember($this->options['caching_key'], $this->options['caching_time'], function () {
+                    return $this->prepareData();
+                });
+            } else {
+                $this->datasets[] = $this->prepareData();
+            }
         }
     }
 


### PR DESCRIPTION
As described in issue #74 (Optimization) the query is always `select * from table` which means that you always load thousands of models in bigger projects. In many cases, however, the data is not constantly updated so that the chart remains unchanged. For this purpose I have implemented a simple caching mechanism.

Just add a unique caching key and the number of seconds the data should remain in the cache.